### PR TITLE
Fix tests and provide better error paths for authentication

### DIFF
--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -118,7 +118,7 @@ describe('configuration', () => {
 
     expect(config.fastify).toEqual(
       expect.objectContaining({
-        host: 'api_host'
+        host: 'interop_host'
       })
     )
 

--- a/lib/plugins/jwt/index.js
+++ b/lib/plugins/jwt/index.js
@@ -4,10 +4,19 @@ const { Unauthorized } = require('http-errors')
 
 async function jwt(server, options) {
   async function authenticate() {
+    if (!this.headers.authorization) {
+      throw Unauthorized()
+    }
+
     try {
       const data = server.jwt.verify(
         this.headers.authorization.replace(/^Bearer /, '')
       )
+
+      if (!data.id) {
+        throw new Error('Missing id in auth token')
+      }
+
       const query = SQL`SELECT id, public_key AS "publicKey", region FROM nations WHERE id = ${data.id}`
       const { rowCount, rows } = await server.pg.read.query(query)
 

--- a/lib/plugins/jwt/jwt.test.js
+++ b/lib/plugins/jwt/jwt.test.js
@@ -13,6 +13,11 @@ describe('jwt plugin', () => {
   beforeAll(async () => {
     server = require('fastify')()
     server.register(require('.'), options)
+    server.decorate('pg', {
+      read: {
+        query: jest.fn()
+      }
+    })
 
     server.route({
       method: 'GET',
@@ -37,6 +42,15 @@ describe('jwt plugin', () => {
       id: faker.lorem.word()
     }
 
+    server.pg.read.query.mockResolvedValue({
+      rowCount: 1,
+      rows: [{
+        id: result.id,
+        publicKey: faker.lorem.word(),
+        region: faker.lorem.word()
+      }]
+    })
+
     const response = await server.inject({
       method: 'GET',
       url: '/authenticate',
@@ -51,16 +65,37 @@ describe('jwt plugin', () => {
     )
   })
 
-  it('should return a 403 code when a token is missing', async () => {
+  it('should return 401 if token not in db', async () => {
+    const result = {
+      id: faker.lorem.word()
+    }
+
+    server.pg.read.query.mockResolvedValue({
+      rowCount: 0,
+      rows: []
+    })
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/authenticate',
+      headers: {
+        Authorization: `Bearer ${jwt.sign(result, options.security.jwtSecret)}`
+      }
+    })
+
+    expect(response.statusCode).toEqual(401)
+  })
+
+  it('should return a 401 code when a token is missing', async () => {
     const response = await server.inject({
       method: 'GET',
       url: '/authenticate'
     })
 
-    expect(response.statusCode).toEqual(403)
+    expect(response.statusCode).toEqual(401)
   })
 
-  it('should return a 403 code when a token has expired', async () => {
+  it('should return a 401 code when a token has expired', async () => {
     const token = jwt.sign(
       { exp: Math.floor(new Date() / 1000) - 3600 },
       options.security.jwtSecret
@@ -74,10 +109,10 @@ describe('jwt plugin', () => {
       }
     })
 
-    expect(response.statusCode).toEqual(403)
+    expect(response.statusCode).toEqual(401)
   })
 
-  it('should return a 403 code when a refresh token is used', async () => {
+  it('should return a 401 code when a refresh token is used', async () => {
     const token = jwt.sign({ refresh: 'refresh' }, options.security.jwtSecret)
 
     const response = await server.inject({
@@ -88,6 +123,6 @@ describe('jwt plugin', () => {
       }
     })
 
-    expect(response.statusCode).toEqual(403)
+    expect(response.statusCode).toEqual(401)
   })
 })


### PR DESCRIPTION
We had some failing tests, I fixed them.

Some of the errors paths in the authentication process were also implicit, i.e. if the authorisation header was not provided the authentication failed with a `cannot call replace of undefined` error.
I added explicit checks for those errors.