### PR TITLE
Performance optimisation for upload endpoint

### DIFF
--- a/lib/routes/upload/index.js
+++ b/lib/routes/upload/index.js
@@ -2,16 +2,13 @@ const fp = require('fastify-plugin')
 const { BadRequest } = require('http-errors')
 const { JWK, JWS } = require('node-jose')
 const { SQS } = require('aws-sdk')
-const copyFrom = require('pg-copy-streams').from
-const stringify = require('csv-stringify')
-const eos = require('end-of-stream')
-const { promisify } = require('util')
 
 const schema = require('./schema')
-const { exposureInsert, uploadBatchInsert } = require('./query')
 const { metricsInsert } = require('../metrics/query')
-
-const peos = promisify(eos)
+const {
+  uploadBatchInsert
+} = require('./query')
+const pipeline = require('./pipeline')
 
 function pgEscape(value) {
   var escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
@@ -51,58 +48,19 @@ async function upload(server, options, done) {
       )
       const [{ uploadBatchId }] = rows
 
-      // const { rowCount } = await server.pg.write.query(
-      //   exposureInsert({
-      //     uploadBatchId,
-      //     exposures,
-      //     origin: region
-      //   })
-      // )
-
-      const client = await server.pg.write.connect()
-
-      await client.query('BEGIN TRANSACTION')
-      await client.query('CREATE TEMP TABLE temp_exposures (LIKE exposures INCLUDING DEFAULTS) ON COMMIT DROP')
-
-      const stream = client.query(copyFrom(`
-        COPY temp_exposures (
-          upload_batch_id,
-          key_data,
-          rolling_start_number,
-          transmission_risk_level,
-          rolling_period,
-          regions,
-          origin
-        ) FROM STDIN WITH (FORMAT csv)`))
-      const csv = stringify()
-      csv.pipe(stream)
-
-      for (const exposure of exposures) {
-        const row = [
-          uploadBatchId,
-          exposure.keyData,
-          exposure.rollingStartNumber,
-          exposure.transmissionRiskLevel,
-          exposure.rollingPeriod,
-          `{${(exposure.regions || []).map(pgEscape).join(',')}}`,
-          region
-        ]
-
-        csv.write(row)
-      }
-      csv.end()
-
-      await peos(stream)
-
-      await client.query(`
-        INSERT INTO exposures
-        SELECT * FROM temp_exposures
-        ON CONFLICT ON CONSTRAINT exposures_key_data_unique DO NOTHING
-      `)
-
-      await client.query('COMMIT')
-
-      client.release()
+      const rowCount = await pipeline(server.pg.write, flow => {
+        for (const exposure of exposures) {
+          flow.write([
+            uploadBatchId,
+            exposure.keyData,
+            exposure.rollingStartNumber,
+            exposure.transmissionRiskLevel,
+            exposure.rollingPeriod,
+            `{${(exposure.regions || []).map(pgEscape).join(',')}}`,
+            region
+          ])
+        }
+      })
 
       await server.pg.write.query(
         metricsInsert({
@@ -112,7 +70,6 @@ async function upload(server, options, done) {
         })
       )
 
-      const rowCount = false
       if (rowCount && options.aws.batchQueueUrl) {
         const message = {
           QueueUrl: options.aws.batchQueueUrl,

--- a/lib/routes/upload/index.js
+++ b/lib/routes/upload/index.js
@@ -26,6 +26,7 @@ async function upload(server, options, done) {
     method: 'POST',
     url: '/upload',
     schema: schema.upload,
+    bodyLimit: 100 * 1024 * 1024, // 100mb
     handler: async request => {
       const { id, publicKey, region } = await request.authenticate()
       const { batchTag, payload } = request.body

--- a/lib/routes/upload/index.js
+++ b/lib/routes/upload/index.js
@@ -1,10 +1,22 @@
 const fp = require('fastify-plugin')
-const schema = require('./schema')
 const { BadRequest } = require('http-errors')
 const { JWK, JWS } = require('node-jose')
 const { SQS } = require('aws-sdk')
+const copyFrom = require('pg-copy-streams').from
+const stringify = require('csv-stringify')
+const eos = require('end-of-stream')
+const { promisify } = require('util')
+
+const schema = require('./schema')
 const { exposureInsert, uploadBatchInsert } = require('./query')
 const { metricsInsert } = require('../metrics/query')
+
+const peos = promisify(eos)
+
+function pgEscape(value) {
+  var escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return '"' + escaped + '"'
+}
 
 async function upload(server, options, done) {
   const sqs = new SQS({
@@ -39,13 +51,58 @@ async function upload(server, options, done) {
       )
       const [{ uploadBatchId }] = rows
 
-      const { rowCount } = await server.pg.write.query(
-        exposureInsert({
+      // const { rowCount } = await server.pg.write.query(
+      //   exposureInsert({
+      //     uploadBatchId,
+      //     exposures,
+      //     origin: region
+      //   })
+      // )
+
+      const client = await server.pg.write.connect()
+
+      await client.query('BEGIN TRANSACTION')
+      await client.query('CREATE TEMP TABLE temp_exposures (LIKE exposures INCLUDING DEFAULTS) ON COMMIT DROP')
+
+      const stream = client.query(copyFrom(`
+        COPY temp_exposures (
+          upload_batch_id,
+          key_data,
+          rolling_start_number,
+          transmission_risk_level,
+          rolling_period,
+          regions,
+          origin
+        ) FROM STDIN WITH (FORMAT csv)`))
+      const csv = stringify()
+      csv.pipe(stream)
+
+      for (const exposure of exposures) {
+        const row = [
           uploadBatchId,
-          exposures,
-          origin: region
-        })
-      )
+          exposure.keyData,
+          exposure.rollingStartNumber,
+          exposure.transmissionRiskLevel,
+          exposure.rollingPeriod,
+          `{${(exposure.regions || []).map(pgEscape).join(',')}}`,
+          region
+        ]
+
+        csv.write(row)
+      }
+      csv.end()
+
+      await peos(stream)
+
+      await client.query(`
+        INSERT INTO exposures
+        SELECT * FROM temp_exposures
+        ON CONFLICT ON CONSTRAINT exposures_key_data_unique DO NOTHING
+      `)
+
+      await client.query('COMMIT')
+
+      client.release()
 
       await server.pg.write.query(
         metricsInsert({
@@ -55,6 +112,7 @@ async function upload(server, options, done) {
         })
       )
 
+      const rowCount = false
       if (rowCount && options.aws.batchQueueUrl) {
         const message = {
           QueueUrl: options.aws.batchQueueUrl,

--- a/lib/routes/upload/pipeline.js
+++ b/lib/routes/upload/pipeline.js
@@ -1,0 +1,47 @@
+const copyFrom = require('pg-copy-streams').from
+const stringify = require('csv-stringify')
+const { pipeline } = require('stream')
+
+const {
+  exposureCopy,
+  prepareExposureCopy,
+  completeExposureCopy
+} = require('./query')
+
+async function pp(pool, fn) {
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN TRANSACTION')
+    await client.query(prepareExposureCopy())
+
+    await new Promise((resolve, reject) => {
+      const csv = stringify()
+      const db = client.query(copyFrom(exposureCopy()))
+
+      const flow = pipeline(
+        csv,
+        db,
+        err => err ? reject(err) : resolve()
+      )
+
+      fn(csv)
+
+      flow.end()
+    })
+
+    const { rowCount } = await client.query(completeExposureCopy())
+
+    await client.query('COMMIT')
+
+    client.release()
+
+    return rowCount
+  } catch(error) {
+    console.log('err')
+    client.release(error)
+    throw error
+  }
+}
+
+module.exports = pp

--- a/lib/routes/upload/query.js
+++ b/lib/routes/upload/query.js
@@ -7,51 +7,31 @@ const uploadBatchInsert = ({ id, batchTag }) =>
       DO UPDATE SET updated_at = CURRENT_TIMESTAMP
       RETURNING id AS "uploadBatchId"`
 
-const exposureInsert = ({ exposures, origin, uploadBatchId }) => {
-  const query = SQL`
-    INSERT INTO exposures (
+const prepareExposureCopy = () => 'CREATE TEMP TABLE temp_exposures (LIKE exposures INCLUDING DEFAULTS) ON COMMIT DROP'
+
+const exposureCopy = () => {
+  return `
+    COPY temp_exposures (
       upload_batch_id,
       key_data,
-      rolling_period,
       rolling_start_number,
       transmission_risk_level,
+      rolling_period,
       regions,
       origin
-    ) VALUES
-  `
-
-  for (const [
-    index,
-    {
-      keyData,
-      rollingPeriod,
-      rollingStartNumber,
-      transmissionRiskLevel,
-      regions
-    }
-  ] of exposures.entries()) {
-    query.append(
-      SQL`(
-        ${uploadBatchId},
-        ${keyData},
-        ${rollingPeriod},
-        ${rollingStartNumber},
-        ${transmissionRiskLevel},
-        ${regions},
-        ${origin}
-      )`
-    )
-
-    if (index < exposures.length - 1) {
-      query.append(SQL`, `)
-    }
-  }
-
-  query.append(
-    SQL` ON CONFLICT ON CONSTRAINT exposures_key_data_unique DO NOTHING`
-  )
-
-  return query
+    ) FROM STDIN WITH (FORMAT csv)
+   `
 }
 
-module.exports = { exposureInsert, uploadBatchInsert }
+const completeExposureCopy = () => `
+    INSERT INTO exposures
+    SELECT * FROM temp_exposures
+    ON CONFLICT ON CONSTRAINT exposures_key_data_unique DO NOTHING
+  `
+
+module.exports = {
+  prepareExposureCopy,
+  exposureCopy,
+  completeExposureCopy,
+  uploadBatchInsert
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1436,6 +1436,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -2004,6 +2014,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csv-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.5.1.tgz",
+      "integrity": "sha512-HM0/86Ks8OwFbaYLd495tqTs1NhscZL52dC4ieKYumy8+nawQYC0xZ63w1NqLf0M148T2YLYqowoImc1giPn0g=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -3182,6 +3197,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -4517,7 +4539,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "normalize-path": {
           "version": "2.1.1",
@@ -6192,6 +6218,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6522,6 +6555,11 @@
         "has": "^1.0.3"
       }
     },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -6749,6 +6787,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
       "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-copy-streams": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/pg-copy-streams/-/pg-copy-streams-5.1.1.tgz",
+      "integrity": "sha512-ieW6JuiIo/4WQ7n+Wevr9zYvpM1AwUs6EwNCCA0VgKZ6ZQ7Y9k3IW00vqc6svX9FtENhbaTbLN7MxekraCrbfg==",
+      "requires": {
+        "obuf": "^1.1.2"
+      }
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "dependencies": {
     "@nearform/sql": "^1.4.0",
     "aws-sdk": "^2.646.0",
+    "csv-stringify": "^5.5.1",
     "date-fns": "^2.11.1",
     "dotenv": "^6.2.0",
+    "end-of-stream": "^1.4.4",
     "env-schema": "^1.0.0",
     "fastify": "^2.11.0",
     "fastify-autoload": "^1.2.0",
@@ -40,6 +42,7 @@
     "node-jose": "^1.1.4",
     "nodemon": "^2.0.1",
     "pg": "^7.18.2",
+    "pg-copy-streams": "^5.1.1",
     "pg-range": "^1.1.0",
     "postgrator": "^3.11.0",
     "under-pressure": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "csv-stringify": "^5.5.1",
     "date-fns": "^2.11.1",
     "dotenv": "^6.2.0",
-    "end-of-stream": "^1.4.4",
     "env-schema": "^1.0.0",
     "fastify": "^2.11.0",
     "fastify-autoload": "^1.2.0",


### PR DESCRIPTION
I replaced the regular insert with [pg-copy-stream](https://github.com/brianc/node-pg-copy-streams) and I'm seeing a reduction of response time of 2 order of magnitudes, from 2900ms to 90ms.

The reason for the speed is that:
1. we are not building a huge query with lot of concatenations and serialising a lot of objects
2. the `copy` command is faster than the `insert`

I've also changed the body limit in fastify just for the upload endpoint to 100mb.

With this changes I was able to upload 500k exposures in a single batch in around 2.2 seconds.
Performance on ECS will be more limited as cpu and memory will be more constrained, but we should still see a nice improvement.
