### PR TITLE
Fix end of pipeline stream

### DIFF
--- a/lib/routes/upload/pipeline.js
+++ b/lib/routes/upload/pipeline.js
@@ -19,7 +19,7 @@ async function pp(pool, fn) {
       const csv = stringify()
       const db = client.query(copyFrom(exposureCopy()))
 
-      const flow = pipeline(
+      pipeline(
         csv,
         db,
         err => err ? reject(err) : resolve()
@@ -27,7 +27,7 @@ async function pp(pool, fn) {
 
       fn(csv)
 
-      flow.end()
+      csv.end()
     })
 
     const { rowCount } = await client.query(completeExposureCopy())
@@ -38,7 +38,6 @@ async function pp(pool, fn) {
 
     return rowCount
   } catch(error) {
-    console.log('err')
     client.release(error)
     throw error
   }


### PR DESCRIPTION
Calling `.end` on `flow` instead of `csv` was closing the streams before all the rows were written to the database.
This is because `stream.pipeline` returns the last stream.